### PR TITLE
パスワード再設定ページ 実装

### DIFF
--- a/lib/pages/reset_password_page.dart
+++ b/lib/pages/reset_password_page.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
@@ -11,12 +12,24 @@ class ResetPassword extends StatefulWidget {
 }
 
 class _ResetPasswordState extends State<ResetPassword> {
-  int _counter = 100;
+  // メッセージ表示用
+  String infoText = '';
+  // 入力メールアドレス
+  String email = '';
 
-  void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+
+  void _sendPasswordResetEmail() async{
+    try {
+      await _auth.sendPasswordResetEmail(email: email);
+      setState(() {
+        infoText = 'パスワード再設定用のメールを送信しました。';
+      });
+    } catch (e) {
+      setState(() {
+        infoText = "パスワード再設定用のメールを送信に失敗しました：${e.toString()}";
+      });
+    }
   }
 
   @override
@@ -29,15 +42,21 @@ class _ResetPasswordState extends State<ResetPassword> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
+            Text(infoText),
             TextField(
               obscureText:false,
               decoration: const InputDecoration(
                 hintText: 'Type your email address',
                 labelText: 'email address',
               ),
+              onChanged: (String value) {
+                setState(() {
+                  email = value;
+                });
+              }
             ),
             FlatButton(
-              onPressed: _incrementCounter,
+              onPressed: _sendPasswordResetEmail,
               color: Colors.blue,
               child: Text(
                 'リセットメールを送信',


### PR DESCRIPTION
パスワードの再設定まで実装
当画面の処理フロー
１．メールアドレスの入力
２．パスワード再設定ボタンの押下でメール送信処理
　⇒成功の場合メール送信
　　失敗の場合エラー表示
３．送信成功時、メールが届く
４．メールリンククリックで再設定ページ表示（Firebase側で準備されているページ）

気になる点あるので今度話しましょう
